### PR TITLE
Removes margin from top of p to ensure alignment

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -12,6 +12,10 @@ a {
   white-space: no-wrap;
 }
 
+p {
+  margin-block-start: 0;
+}
+
 body > header,
 body > nav {
   min-height: 20vh;


### PR DESCRIPTION
Sets `margin-block-start` to `0` to remove it.